### PR TITLE
Remove block margins from paginated pages

### DIFF
--- a/src/vfrag.css
+++ b/src/vfrag.css
@@ -31,7 +31,7 @@ figcaption:where(:last-child) {
    so this prevents issues where a tiny amount of overflow causes the UA to create a new page.
  */
 @page paginated {
-	margin-block-end: 0;
+	margin-block: 0;
 }
 
 :where(.pagination-root) {


### PR DESCRIPTION
We need them for running headers and page numbers.